### PR TITLE
 master-task/#72/소스 파일 디텍딩 속도 개선

### DIFF
--- a/src/main/java/com/jerry/handler/ProjectFileArgumentResolver.java
+++ b/src/main/java/com/jerry/handler/ProjectFileArgumentResolver.java
@@ -67,6 +67,9 @@ public class ProjectFileArgumentResolver implements HandlerMethodArgumentResolve
 			if (isFind) {
 				break;
 			}
+			if (!file.getAbsolutePath().contains("src")) {
+				continue;
+			}
 			if (file.isDirectory()) {
 				this.getJavaFileFromFileName(file.listFiles(), fileName);
 			}

--- a/src/main/resources/static/css/index.css
+++ b/src/main/resources/static/css/index.css
@@ -142,3 +142,7 @@ p {
 	background-color: aqua;
 	font-weight: bold;
 }
+
+.errorLine {
+	background-color: red;
+}

--- a/src/main/resources/static/src/Renderer.ts
+++ b/src/main/resources/static/src/Renderer.ts
@@ -104,7 +104,7 @@ export class Renderer {
 						p.className = 'codestyle';
 
 						if (lineNumber === aResponse[i].substring(0, aResponse[i].indexOf('&nbsp') - 1)) {
-							$(p).css('color: red; font-weight: bold');
+							$(p).addClass('errorLine');
 						} else {
 							aResponse[i] = self.theme.render(aResponse[i]);
 						}


### PR DESCRIPTION
- 메이븐의 스탠다드 디렉토리 레이아웃 규칙의 기반으로 소스파일은 src/아래에 존재한다는 전제하에 조건 추가
- 에러가 발생한 위치 스타일 수정